### PR TITLE
feat: additional environment variables config option

### DIFF
--- a/src/main/java/de/voasis/nebula/Data/Data.java
+++ b/src/main/java/de/voasis/nebula/Data/Data.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public class Data {
     public static String vsecret;
+    public static String envVars;
     public static String defaultServerTemplate;
     public static List<String> adminUUIDs = new ArrayList<>();
     public static int defaultmax;

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -16,8 +16,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class FilesManager {
 
@@ -38,7 +40,7 @@ public class FilesManager {
             Data.defaultmin = config.node("lobby-min").getInt();
             Data.vsecret = config.node("vsecret").getString();
             String envVars = config.node("env-vars").getString();
-            Data.envVars = envVars != null ? envVars : "";
+            Data.envVars = envVars != null ? Arrays.stream(envVars.split(",")).map(s -> " -e "+s).collect(Collectors.joining()) : "";
             String adminList = config.node("admins").getString();
             Data.adminUUIDs = adminList != null ? List.of(adminList.split(",")) : List.of();
             logger.info("Admin UUIDS: {}", Data.adminUUIDs);

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -37,6 +37,8 @@ public class FilesManager {
             Data.defaultmax = config.node("lobby-max").getInt();
             Data.defaultmin = config.node("lobby-min").getInt();
             Data.vsecret = config.node("vsecret").getString();
+            String envVars = config.node("env-vars").getString();
+            Data.envVars = envVars != null ? envVars : "";
             String adminList = config.node("admins").getString();
             Data.adminUUIDs = adminList != null ? List.of(adminList.split(",")) : List.of();
             logger.info("Admin UUIDS: {}", Data.adminUUIDs);

--- a/src/main/java/de/voasis/nebula/ServerManager.java
+++ b/src/main/java/de/voasis/nebula/ServerManager.java
@@ -65,7 +65,7 @@ public class ServerManager {
             }
         }
         int tempPort = externalServer.getFreePort();
-        String command = String.format("docker run -d -e PAPER_VELOCITY_SECRET=%s -p %d:25565 --name %s %s", Data.vsecret, tempPort, FinalNewName, templateName);
+        String command = String.format("docker run -d -e PAPER_VELOCITY_SECRET=%s %s -p %d:25565 --name %s %s", Data.vsecret, Data.envVars, tempPort, FinalNewName, templateName);
         Nebula.util.sendMessage(source, Messages.CREATE_CONTAINER.replace("<name>", FinalNewName));
         BackendServer backendServer = new BackendServer(FinalNewName, externalServer, tempPort, false, source, templateName, tag);
         HoldServer finalExternalServer = externalServer;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@ admins: 74401e14-f69c-48f3-b393-64be488dff8f,069a79f4-44e9-4726-a5be-fca90e38aaf
 # Velocity Secret
 vsecret: <VELOCITY-SECRET>
 # Additional environment variables
-env-vars: FOO=bar FOO2=bar2
+env-vars: FOO=bar,FOO2=bar2
 # Docherhub Template for the Default-Servers.
 lobby-template: anton691/simple-lobby:latest
 # Player limit for default server.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,8 @@ file-version: 1
 admins: 74401e14-f69c-48f3-b393-64be488dff8f,069a79f4-44e9-4726-a5be-fca90e38aaf5
 # Velocity Secret
 vsecret: <VELOCITY-SECRET>
+# Additional environment variables
+env-vars: FOO=bar FOO2=bar2
 # Docherhub Template for the Default-Servers.
 lobby-template: anton691/simple-lobby:latest
 # Player limit for default server.


### PR DESCRIPTION
Adds an optional config option for additional environment variables to be passed to launched servers
Example use case: passing credentials and addresses for a database