### PR TITLE
feat: leave_queue plugin message

### DIFF
--- a/src/main/java/de/voasis/nebula/Event/Events/PluginMessage.java
+++ b/src/main/java/de/voasis/nebula/Event/Events/PluginMessage.java
@@ -25,6 +25,10 @@ public class PluginMessage {
                     return;
                 }
                 Nebula.util.joinQueue(player.get(), messageContent.split(":")[2]);
+            } else if (messageContent.startsWith("leave_queue:")) {
+                if (messageContent.split(":").length != 2) logger.warn("Incorrect leave queue plugin message format: {}", messageContent);
+                Optional<Player> player = server.getPlayer(messageContent.split(":")[1]);
+                player.ifPresent(p -> Nebula.util.leaveQueue(p));
             }
         }
     }


### PR DESCRIPTION
Adds a plugin message for removing a player from its queue.
Format: `leave_queue:username`

Tested and working
![image](https://github.com/user-attachments/assets/b44142da-982a-42ed-8bff-27b9558a08fa)
