### PR TITLE
feat: queue pre-processing and parallelization

### DIFF
--- a/src/main/java/de/voasis/nebula/Data/Data.java
+++ b/src/main/java/de/voasis/nebula/Data/Data.java
@@ -18,7 +18,7 @@ public class Data {
     public static List<HoldServer> holdServerMap = new ArrayList<>();
     public static List<BackendServer> backendInfoMap = new ArrayList<>();
     public static List<GamemodeQueue> gamemodeQueueMap = new ArrayList<>();
-    public static Map<GamemodeQueue, BackendServer> preloadedGameServers = new HashMap<>();
+    public static Map<GamemodeQueue, List<BackendServer>> preloadedGameServers = new HashMap<>();
     public static List<String> alltemplates = new ArrayList<>();
     public static String Icon = """
                 \n

--- a/src/main/java/de/voasis/nebula/Data/Data.java
+++ b/src/main/java/de/voasis/nebula/Data/Data.java
@@ -4,7 +4,9 @@ import de.voasis.nebula.Maps.BackendServer;
 import de.voasis.nebula.Maps.GamemodeQueue;
 import de.voasis.nebula.Maps.HoldServer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Data {
     public static String vsecret;
@@ -16,6 +18,7 @@ public class Data {
     public static List<HoldServer> holdServerMap = new ArrayList<>();
     public static List<BackendServer> backendInfoMap = new ArrayList<>();
     public static List<GamemodeQueue> gamemodeQueueMap = new ArrayList<>();
+    public static Map<GamemodeQueue, BackendServer> preloadedGameServers = new HashMap<>();
     public static List<String> alltemplates = new ArrayList<>();
     public static String Icon = """
                 \n

--- a/src/main/java/de/voasis/nebula/Helper/AutoDeleter.java
+++ b/src/main/java/de/voasis/nebula/Helper/AutoDeleter.java
@@ -23,7 +23,7 @@ public class AutoDeleter {
                 continue;
             }
             boolean conditionsMet = Nebula.util.getPlayerCount(backendServer) == 0 &&
-                    backendServer.getPendingPlayerConnections().isEmpty();
+                    backendServer.getPendingPlayerConnections().isEmpty() && !backendServer.isPreloadedGameServer();
             if (backendServer.getTag().equals("lobby")) {
                 conditionsMet = conditionsMet && !lobbyServerDeleted && canDeleteLobbyServer(backendServer);
             }

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -70,8 +70,9 @@ public class FilesManager {
                 for (Object queueName : gamemodes.keySet()) {
                     String template = config.node("gamemodes", queueName, "templateName").getString();
                     int neededPlayers = config.node("gamemodes", queueName, "neededPlayers").getInt();
+                    boolean preload = config.node("gamemodes", queueName, "preload").getBoolean();
                     Data.alltemplates.add(template);
-                    Data.gamemodeQueueMap.add(new GamemodeQueue(queueName.toString(), template, neededPlayers));
+                    Data.gamemodeQueueMap.add(new GamemodeQueue(queueName.toString(), template, neededPlayers, preload));
                     logger.info("Added gamemode to pool: {}, {}, {}.", queueName, template, neededPlayers);
                 }
             }

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -70,7 +70,7 @@ public class FilesManager {
                 for (Object queueName : gamemodes.keySet()) {
                     String template = config.node("gamemodes", queueName, "templateName").getString();
                     int neededPlayers = config.node("gamemodes", queueName, "neededPlayers").getInt();
-                    boolean preload = config.node("gamemodes", queueName, "preload").getBoolean();
+                    int preload = config.node("gamemodes", queueName, "preload").getInt();
                     Data.alltemplates.add(template);
                     Data.gamemodeQueueMap.add(new GamemodeQueue(queueName.toString(), template, neededPlayers, preload));
                     logger.info("Added gamemode to pool: {}, {}, {}.", queueName, template, neededPlayers);

--- a/src/main/java/de/voasis/nebula/Helper/QueueProcessor.java
+++ b/src/main/java/de/voasis/nebula/Helper/QueueProcessor.java
@@ -3,10 +3,8 @@ package de.voasis.nebula.Helper;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import de.voasis.nebula.Data.Data;
-import de.voasis.nebula.Data.Util;
 import de.voasis.nebula.Maps.BackendServer;
-import de.voasis.nebula.Maps.GamemodeQueue;
-import de.voasis.nebula.Nebula;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/de/voasis/nebula/Helper/QueueProcessor.java
+++ b/src/main/java/de/voasis/nebula/Helper/QueueProcessor.java
@@ -22,13 +22,7 @@ public class QueueProcessor {
         Data.gamemodeQueueMap.parallelStream().forEach(queue -> {
             if (queue.isPreload() && !Data.preloadedGameServers.containsKey(queue)) {
                 Data.preloadedGameServers.put(queue, null);
-                String name = queue.getName() + "-" + Util.generateUniqueString();
-                BackendServer preloadedServer = Nebula.serverManager.createFromTemplate(
-                        queue.getTemplate(),
-                        name,
-                        server.getConsoleCommandSource(),
-                        "gamemode:" + queue.getName()
-                );
+                BackendServer preloadedServer = queue.createServer(server);
                 Data.preloadedGameServers.put(queue, preloadedServer);
             }
             int neededPlayers = queue.getNeededPlayers();
@@ -40,15 +34,7 @@ public class QueueProcessor {
                 }
                 BackendServer newServer;
                 if (queue.isPreload()) newServer = Data.preloadedGameServers.get(queue);
-                else {
-                    String name = queue.getName() + "-" + Util.generateUniqueString();
-                    newServer = Nebula.serverManager.createFromTemplate(
-                            queue.getTemplate(),
-                            name,
-                            server.getConsoleCommandSource(),
-                            "gamemode:" + queue.getName()
-                    );
-                }
+                else newServer = queue.createServer(server);
                 for (Player player : playersToMove) {
                     newServer.addPendingPlayerConnection(player);
                 }

--- a/src/main/java/de/voasis/nebula/Maps/BackendServer.java
+++ b/src/main/java/de/voasis/nebula/Maps/BackendServer.java
@@ -2,6 +2,8 @@ package de.voasis.nebula.Maps;
 
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import de.voasis.nebula.Data.Data;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +26,13 @@ public class BackendServer {
         this.creator = creator;
         this.template = template;
         this.tag = tag;
+    }
+
+    public boolean isPreloadedGameServer() {
+        for (List<BackendServer> backendServers: Data.preloadedGameServers.values()) {
+            if (backendServers.contains(this)) return true;
+        }
+        return false;
     }
 
     public String getServerName() { return serverName; }

--- a/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
+++ b/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
@@ -2,7 +2,6 @@ package de.voasis.nebula.Maps;
 
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import de.voasis.nebula.Data.Data;
 import de.voasis.nebula.Data.Util;
 import de.voasis.nebula.Nebula;
 

--- a/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
+++ b/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
@@ -1,6 +1,11 @@
 package de.voasis.nebula.Maps;
 
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.voasis.nebula.Data.Data;
+import de.voasis.nebula.Data.Util;
+import de.voasis.nebula.Nebula;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,6 +22,15 @@ public class GamemodeQueue {
         this.template = template;
         this.neededPlayers = neededPlayers;
         this.preload = preload;
+    }
+
+    public BackendServer createServer(ProxyServer server) {
+        return Nebula.serverManager.createFromTemplate(
+                getTemplate(),
+                getName() + "-" + Util.generateUniqueString(),
+                server.getConsoleCommandSource(),
+                "gamemode:" + getName()
+        );
     }
 
     public String getName() { return name; }

--- a/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
+++ b/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
@@ -13,10 +13,10 @@ public class GamemodeQueue {
     private final String name;
     private final String template;
     private final int neededPlayers;
-    private final boolean preload;
+    private final int preload;
     private List<Player> inQueue = new ArrayList<>();
 
-    public GamemodeQueue(String name, String template, int neededPlayers, boolean preload) {
+    public GamemodeQueue(String name, String template, int neededPlayers, int preload) {
         this.name = name;
         this.template = template;
         this.neededPlayers = neededPlayers;
@@ -36,5 +36,5 @@ public class GamemodeQueue {
     public String getTemplate() { return template; }
     public int getNeededPlayers() { return neededPlayers; }
     public List<Player> getInQueue() { return inQueue; }
-    public boolean isPreload() { return preload; }
+    public int getPreload() { return preload; }
 }

--- a/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
+++ b/src/main/java/de/voasis/nebula/Maps/GamemodeQueue.java
@@ -9,16 +9,19 @@ public class GamemodeQueue {
     private final String name;
     private final String template;
     private final int neededPlayers;
+    private final boolean preload;
     private List<Player> inQueue = new ArrayList<>();
 
-    public GamemodeQueue(String name, String template, int neededPlayers) {
+    public GamemodeQueue(String name, String template, int neededPlayers, boolean preload) {
         this.name = name;
         this.template = template;
         this.neededPlayers = neededPlayers;
+        this.preload = preload;
     }
 
     public String getName() { return name; }
     public String getTemplate() { return template; }
     public int getNeededPlayers() { return neededPlayers; }
     public List<Player> getInQueue() { return inQueue; }
+    public boolean isPreload() { return preload; }
 }

--- a/src/main/java/de/voasis/nebula/ServerManager.java
+++ b/src/main/java/de/voasis/nebula/ServerManager.java
@@ -67,7 +67,6 @@ public class ServerManager {
         int tempPort = externalServer.getFreePort();
         String command = String.format("docker run -d -e PAPER_VELOCITY_SECRET=%s %s -p %d:25565 --name %s %s", Data.vsecret, Data.envVars, tempPort, FinalNewName, templateName);
         Nebula.util.updateFreePort(externalServer);
-        System.out.println(command);
         Nebula.util.sendMessage(source, Messages.CREATE_CONTAINER.replace("<name>", FinalNewName));
         BackendServer backendServer = new BackendServer(FinalNewName, externalServer, tempPort, false, source, templateName, tag);
         HoldServer finalExternalServer = externalServer;

--- a/src/main/java/de/voasis/nebula/ServerManager.java
+++ b/src/main/java/de/voasis/nebula/ServerManager.java
@@ -66,6 +66,8 @@ public class ServerManager {
         }
         int tempPort = externalServer.getFreePort();
         String command = String.format("docker run -d -e PAPER_VELOCITY_SECRET=%s %s -p %d:25565 --name %s %s", Data.vsecret, Data.envVars, tempPort, FinalNewName, templateName);
+        Nebula.util.updateFreePort(externalServer);
+        System.out.println(command);
         Nebula.util.sendMessage(source, Messages.CREATE_CONTAINER.replace("<name>", FinalNewName));
         BackendServer backendServer = new BackendServer(FinalNewName, externalServer, tempPort, false, source, templateName, tag);
         HoldServer finalExternalServer = externalServer;
@@ -74,7 +76,6 @@ public class ServerManager {
                     ServerInfo newInfo = new ServerInfo(FinalNewName, new InetSocketAddress(finalExternalServer.getIp(), tempPort));
                     server.registerServer(newInfo);
                     Data.backendInfoMap.add(backendServer);
-                    Nebula.util.updateFreePort(finalExternalServer);
                     Nebula.util.sendMessage(source, Messages.DONE);
                 },
                 () -> Nebula.util.sendMessage(source, Messages.ERROR_CREATE.replace("<name>", FinalNewName))

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,4 +25,4 @@ gamemodes:
   Duels:
     templateName: anton691/simple-duels:latest
     neededPlayers: 2
-    preload: false
+    preload: 0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,4 +25,4 @@ gamemodes:
   Duels:
     templateName: anton691/simple-duels:latest
     neededPlayers: 2
-
+    preload: false


### PR DESCRIPTION
This PR adds a `preload` boolean config option to gamemodes. When QueueProcessor#process is called, if a queue has this option set to `true` and doesn't already have a preloaded server on hold, it will create one, which will be used to warp when the player count reaches the required amount. This allows for bigger servers to be launched and joined without players having to wait if their queue has enough participants.
This PR also replaces the for loop on the GamemodeQueues with a parallel stream in order to avoid all the for loop being stalled by the creation of a server when only the thread of the current iteration should be.

Currently marked as draft, because of the extensive testing needed and the following:.
If you're interested in this PR, I'd like to also add a minimum player count in queue to preload a server in order to reduce load times without having empty servers running for too long. This would also come with preloaded server deletion if queue is empty for some time