### PR TITLE
feat: parallelize docker pulling on Hold Servers

### DIFF
--- a/src/main/java/de/voasis/nebula/Data/Messages.java
+++ b/src/main/java/de/voasis/nebula/Data/Messages.java
@@ -7,6 +7,7 @@ public class Messages {
     public static String KILL_CONTAINER;
     public static String DELETE_CONTAINER;
     public static String PULL_TEMPLATE;
+    public static String DONE_PULL;
     public static String CREATE_CONTAINER;
     public static String START_CONTAINER;
     public static String SERVER_RUNNING;

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -98,6 +98,7 @@ public class FilesManager {
             Messages.CREATE_CONTAINER = messages.node("admin", "server-create").getString("<pre>Creating server instance from template...").replace("<pre>", prefix);
             Messages.START_CONTAINER = messages.node("admin", "server-start").getString("<pre>Starting server instance <name>.").replace("<pre>", prefix);
             Messages.PULL_TEMPLATE = messages.node("admin", "server-pull").getString("<pre>Pulling template <template> on server <name>.").replace("<pre>", prefix);
+            Messages.DONE_PULL = messages.node("admin", "done-pull").getString("<pre>Done pulling template <template> on server <name>.").replace("<pre>", prefix);
             Messages.ALREADY_EXISTS = messages.node("admin", "server-exists").getString("<pre>Server <name> already exists.").replace("<pre>", prefix);
             Messages.SERVER_CONNECT = messages.node("util", "server-connect").getString("<green>Connecting to server <name>...").replace("<pre>", prefix);
             Messages.SERVER_RUNNING = messages.node("admin", "server-running").getString("<pre>Server <name> is already running.").replace("<pre>", prefix);

--- a/src/main/java/de/voasis/nebula/Helper/FilesManager.java
+++ b/src/main/java/de/voasis/nebula/Helper/FilesManager.java
@@ -76,11 +76,11 @@ public class FilesManager {
             }
             Data.alltemplates.add(Data.defaultServerTemplate);
             if(Data.pullStart) {
-                for (HoldServer holdServer : Data.holdServerMap) {
-                    for (String template : Data.alltemplates) {
+                Data.holdServerMap.parallelStream().forEach(holdServer -> {
+                    Data.alltemplates.parallelStream().forEach(template -> {
                         Nebula.serverManager.pull(holdServer, template, server.getConsoleCommandSource());
-                    }
-                }
+                    });
+                });
             }
         } catch (Exception e) {
             Nebula.util.log("Error in configuration loading", e);

--- a/src/main/java/de/voasis/nebula/ServerManager.java
+++ b/src/main/java/de/voasis/nebula/ServerManager.java
@@ -136,7 +136,7 @@ public class ServerManager {
         String externName = externalServer.getServerName();
         Nebula.util.sendMessage(source, Messages.PULL_TEMPLATE.replace("<name>", externName).replace("<template>", template));
         executeSSHCommand(externalServer, "docker pull " + template,
-                () -> Nebula.util.sendMessage(source, Messages.DONE),
+                () -> Nebula.util.sendMessage(source, Messages.DONE_PULL.replace("<name>", externName).replace("<template>", template)),
                 () -> Nebula.util.sendMessage(source, Messages.ERROR_PULL.replace("<name>", externName).replace("<template>", template))
         );
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -9,6 +9,7 @@ admin:
   kill-start: "<pre>Killing server instance <name>."
   delete-start: "<pre>Deleting server instance <name>."
   server-pull: "<pre>Pulling template <template> on server <name>."
+  done-pull: "<pre>Done pulling template <template> on server <name>."
   server-create: "<pre>Creating server instance <name>."
   server-start: "<pre>Starting server instance <name>."
   server-error: "<pre>Failed to create container: <name>."


### PR DESCRIPTION
This PR makes the pulling of docker images from the templates on hold servers parallel. This allows for a gigantic boost in speed, as the commands no longer have to wait for the previous one to finish and can instead run at the same time. This allows a speed improvement by approximately `number of hold server` times `amount of templates`
This change is made possible due to pulling images not requiring a specific state or specific values (e.g. port number) to run.
A parallel `Stream#forEach` waits for all the tasks to finish before returning, which means it can still be used in a sync context and return **after** all commands have been executed, which means the current behavior of `FilesManager#load` *will not* change.

Possible bottlenecks/issues:
* While this makes a huge improvement in speed, the pulling of the images is still capped by the hold server's download speed
* The proxy has to run one SSH session per image pulled, which could be blocked by the Hold Server's spam detection/DDOS protection. This should not happen as long as the amount of templates does not reach irreasonnable numbers, and can be worked around by whitelisting the proxy's IP anyway. A future improvement to this could be having a way to run multiple commands on a single SSH session, either by leaving one open or adding a method to run multiple commands in a single session.

(Changes have been tested and work as of my testing)